### PR TITLE
Redesign layout with mobile first styles

### DIFF
--- a/src/components/Footer/StylesFooter.css
+++ b/src/components/Footer/StylesFooter.css
@@ -3,25 +3,28 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-top: 0.8rem;
+  padding: 1rem;
   position: sticky;
   bottom: 0;
   background-color: #dfecea;
-  height: 2.8rem;
 }
 
 .form-footer div {
   background-color: white;
-  padding: 5px;
+  padding: 0.5rem 1rem;
   border-radius: 3px;
   color: var(--headers);
-  font-size: 1.3rem;
+  font-size: 1rem;
 }
 
-/* Reponsividade */
+@media (min-width: 768px) {
+  .form-footer div {
+    font-size: 1.2rem;
+  }
+}
 
-@media (max-width: 1080px) {
-  .form-footer {
-    padding: 1.5rem;
+@media (min-width: 1080px) {
+  .form-footer div {
+    font-size: 1.3rem;
   }
 }

--- a/src/components/Footer/StylesFooter.css
+++ b/src/components/Footer/StylesFooter.css
@@ -6,7 +6,7 @@
   padding: 1rem;
   position: sticky;
   bottom: 0;
-  background-color: #dfecea;
+  background-color: var(--background);
 }
 
 .form-footer div {

--- a/src/components/Form/FormStyle.css
+++ b/src/components/Form/FormStyle.css
@@ -18,10 +18,12 @@ p {
 
 .form-container {
   width: 100%;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   justify-content: center;
-  gap: 3rem;
+  gap: 2rem;
   text-align: center;
+  padding: 1rem;
 }
 
 .container-img {
@@ -30,7 +32,7 @@ p {
   align-items: center;
   width: 50%;
   margin: 0 auto;
-  height: 33rem;
+  height: 24rem;
 }
 
 .imagem-avatar {
@@ -98,6 +100,8 @@ p {
 .form-section-four {
   display: grid;
   width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   padding: 2rem;
 }
@@ -105,12 +109,16 @@ p {
 .form-section-input-text {
   display: grid;
   width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   padding: 2rem;
 }
 
 .form-section-input-date {
   width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   padding: 2rem;
 }
@@ -137,6 +145,8 @@ input[type="date"] {
 
 .form-section-input-select {
   width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   padding: 2rem;
 }
@@ -144,6 +154,8 @@ input[type="date"] {
 .form-section-input-creditCard {
   display: grid;
   width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   padding: 2rem;
 }
@@ -256,27 +268,17 @@ option {
 /* ---- */
 
 /* RESPONSIVIDADE */
-@media (max-width: 1080px) {
+@media (min-width: 768px) {
   .form-section-one,
   .form-section-two,
   .form-section-three,
-  .form-section-four {
-    width: 30rem;
-  }
-  .warning-text {
-    width: 30rem;
-  }
-
-  .form-section-input-creditCard {
-    width: 30rem;
-  }
-
-  .form-section-input-text {
-    width: 30rem;
-  }
-
-  .form-section-input-select {
-    width: 30rem;
+  .form-section-four,
+  .form-section-input-creditCard,
+  .form-section-input-text,
+  .form-section-input-select,
+  .warning-text,
+  .form-section-glitter {
+    max-width: 600px;
   }
 
   h2 {
@@ -301,10 +303,25 @@ option {
     width: 1.3rem;
     height: 1.3rem;
   }
+
   input[type="checkbox"]:checked::after {
     content: " ";
     width: 0.6rem;
     height: 0.6rem;
+  }
+}
+
+@media (min-width: 1080px) {
+  .form-section-one,
+  .form-section-two,
+  .form-section-three,
+  .form-section-four,
+  .form-section-input-creditCard,
+  .form-section-input-text,
+  .form-section-input-select,
+  .warning-text,
+  .form-section-glitter {
+    max-width: 700px;
   }
 }
 

--- a/src/components/Form/FormStyle.css
+++ b/src/components/Form/FormStyle.css
@@ -21,7 +21,7 @@ p {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 2rem;
+  gap: 1.5rem;
   text-align: center;
   padding: 1rem;
 }
@@ -46,12 +46,13 @@ p {
 
 .alert-section {
   display: grid;
-  margin: 0 auto;
+  margin: 1rem auto;
   place-items: center;
   width: 80%;
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+  background: #fff;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   height: 13rem;
-  border-radius: 2rem;
+  border-radius: 1rem;
   padding: 1.2rem;
 }
 .alert-section h3 {
@@ -69,7 +70,10 @@ p {
 
 .warning-text {
   width: 100%;
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+  margin: 1rem auto;
+  background: #fff;
+  border-radius: 1rem;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   padding: 1.5rem;
 }
 
@@ -101,26 +105,32 @@ p {
   display: grid;
   width: 100%;
   max-width: 480px;
-  margin: 0 auto;
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
-  padding: 2rem;
+  margin: 1rem auto;
+  background: #fff;
+  border-radius: 1rem;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  padding: 1.5rem;
 }
 
 .form-section-input-text {
   display: grid;
   width: 100%;
   max-width: 480px;
-  margin: 0 auto;
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
-  padding: 2rem;
+  margin: 1rem auto;
+  background: #fff;
+  border-radius: 1rem;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  padding: 1.5rem;
 }
 
 .form-section-input-date {
   width: 100%;
   max-width: 480px;
-  margin: 0 auto;
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
-  padding: 2rem;
+  margin: 1rem auto;
+  background: #fff;
+  border-radius: 1rem;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  padding: 1.5rem;
 }
 
 .form-section-input-date input {
@@ -146,18 +156,22 @@ input[type="date"] {
 .form-section-input-select {
   width: 100%;
   max-width: 480px;
-  margin: 0 auto;
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
-  padding: 2rem;
+  margin: 1rem auto;
+  background: #fff;
+  border-radius: 1rem;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  padding: 1.5rem;
 }
 
 .form-section-input-creditCard {
   display: grid;
   width: 100%;
   max-width: 480px;
-  margin: 0 auto;
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
-  padding: 2rem;
+  margin: 1rem auto;
+  background: #fff;
+  border-radius: 1rem;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  padding: 1.5rem;
 }
 
 .form-section-input-creditCard select {
@@ -235,7 +249,7 @@ input[type="checkbox"]:checked::after {
 .button-resume-modal {
   width: 100%;
   padding: 1.5rem;
-  background: #33cc95;
+  background: var(--headers);
   color: #fff;
   border-radius: 0.5rem;
   border: 0;
@@ -248,7 +262,7 @@ input[type="checkbox"]:checked::after {
   margin: 1rem 0;
   width: 20rem;
   padding: 1rem;
-  background: #33cc95;
+  background: var(--headers);
   color: #fff;
   border-radius: 0.5rem;
   font-size: 1rem;

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -5,7 +5,7 @@ import { BiMap } from "react-icons/bi";
 
 export const Header = () => {
   return (
-    <header className="header-container">
+    <header className="header-container" data-aos="fade-down" data-aos-duration="800">
       <div className="content-box-header">
         <div>
           <a href="">

--- a/src/components/Header/StylesHeader.css
+++ b/src/components/Header/StylesHeader.css
@@ -1,6 +1,6 @@
 .header-container {
   width: 100%;
-  height: 20rem;
+  padding: 1rem 0;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -12,23 +12,23 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-width: 1120px;
+  max-width: 600px;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
+  gap: 1rem;
 }
 
 .logo-empresa {
-  width: 100%;
-  height: 10rem;
+  width: 8rem;
 }
 
 .header-list {
   display: flex;
+  gap: 0.5rem;
 }
 
 .header-list li {
   list-style: none;
-  margin: 1rem;
 }
 
 .header-text h2 {
@@ -39,16 +39,16 @@
 }
 
 .header-text svg {
-  width: 1.4rem;
+  width: 1rem;
   position: relative;
-  top: 0.4rem;
+  top: 0.2rem;
 }
 
 /* Link / React-Icons */
 .div-icons {
   border: 2px solid var(--nameEnterprise);
   border-radius: 5px;
-  padding: 2px;
+  padding: 0.25rem;
   line-height: 1;
 }
 
@@ -61,48 +61,37 @@
 
 /* RESPONSIVIDADE */
 
-@media (max-width: 1080px) {
-  .header-text h2 {
-    font-size: 1.3rem;
+@media (min-width: 768px) {
+  .content-box-header {
+    flex-direction: row;
+    justify-content: space-between;
   }
 
-  .header-text svg {
-    width: 1.5rem;
-    position: relative;
-    top: 0.6rem;
-  }
-}
-
-@media (max-width: 720px) {
   .logo-empresa {
-    width: 100%;
-    height: 10rem;
+    width: 12rem;
   }
 
   .header-text h2 {
     font-size: 1.2rem;
+  }
+
+  .header-text svg {
+    width: 1.4rem;
+    top: 0.3rem;
+  }
+}
+
+@media (min-width: 1080px) {
+  .header-text h2 {
+    font-size: 1.4rem;
   }
 
   .header-text svg {
     width: 1.6rem;
-    position: relative;
-    top: 0.6rem;
+    top: 0.4rem;
   }
-}
 
-@media (max-width: 370px) {
   .logo-empresa {
-    width: 100%;
-    height: 9.5rem;
-  }
-
-  .header-text h2 {
-    font-size: 1.2rem;
-  }
-
-  .header-text svg {
-    width: 1.5rem;
-    position: relative;
-    top: 0.6rem;
+    width: 14rem;
   }
 }

--- a/src/components/Header/StylesHeader.css
+++ b/src/components/Header/StylesHeader.css
@@ -1,25 +1,27 @@
 .header-container {
   width: 100%;
-  padding: 1rem 0;
   display: flex;
-  flex-direction: column;
   justify-content: center;
-  align-items: center;
-  background-color: var(--background);
+  background-color: var(--headers);
+  color: #fff;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  padding: 0.75rem 0;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .content-box-header {
   display: flex;
-  flex-direction: column;
-  width: 100%;
-  max-width: 600px;
   align-items: center;
-  justify-content: center;
-  gap: 1rem;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 1120px;
+  padding: 0 1rem;
 }
 
 .logo-empresa {
-  width: 8rem;
+  width: 6rem;
 }
 
 .header-list {
@@ -32,10 +34,10 @@
 }
 
 .header-text h2 {
-  font-size: 1rem;
-  text-align: center;
-  font-weight: 900;
-  color: var(--nameEnterprise);
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-align: left;
+  color: #fff;
 }
 
 .header-text svg {
@@ -46,7 +48,7 @@
 
 /* Link / React-Icons */
 .div-icons {
-  border: 2px solid var(--nameEnterprise);
+  border: 2px solid #fff;
   border-radius: 5px;
   padding: 0.25rem;
   line-height: 1;

--- a/src/components/RenderGlitter/StylesRenderGlitter.css
+++ b/src/components/RenderGlitter/StylesRenderGlitter.css
@@ -2,7 +2,9 @@
   display: grid;
   width: 100%;
   max-width: 480px;
-  margin: 0 auto;
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
-  padding: 2rem;
+  margin: 1rem auto;
+  background: #fff;
+  border-radius: 1rem;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  padding: 1.5rem;
 }

--- a/src/components/RenderGlitter/StylesRenderGlitter.css
+++ b/src/components/RenderGlitter/StylesRenderGlitter.css
@@ -1,6 +1,8 @@
 .form-section-glitter {
   display: grid;
   width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   padding: 2rem;
 }

--- a/src/components/ResumeModal/StylesResumeModal.css
+++ b/src/components/ResumeModal/StylesResumeModal.css
@@ -14,7 +14,7 @@
   width: 90%;
   max-width: 576px;
   background: white;
-  padding: 1rem;
+  padding: 2rem;
   position: relative;
   border-radius: 0.25rem;
   margin-top: 1rem;
@@ -54,7 +54,7 @@ button[type="submit"] {
   width: 100%;
   padding: 0 1.5rem;
   height: 4rem;
-  background: #33cc95;
+  background: var(--headers);
   color: #fff;
   border-radius: 0.25rem;
   border: 0;

--- a/src/components/ResumeModal/StylesResumeModal.css
+++ b/src/components/ResumeModal/StylesResumeModal.css
@@ -11,7 +11,7 @@
 }
 
 .react-modal-content {
-  width: 100%;
+  width: 90%;
   max-width: 576px;
   background: white;
   padding: 1rem;
@@ -67,29 +67,12 @@ button[type="submit"]:hover {
   filter: brightness(0.9);
 }
 
-@media (max-width: 728px) {
+@media (min-width: 728px) {
   .react-modal-content {
-    width: 30rem;
     padding: 3rem;
-    overflow: scroll;
-    max-height: 440px;
-    position: relative;
-    border-radius: 8px;
-    margin: 0 auto;
-    font-size: 0.8rem;
-    -webkit-overflow-scrolling: touch;
-  }
-
-  .data-container h1,
-  h3 {
-    line-height: 0.5rem;
   }
 
   button[type="submit"] {
-    position: sticky;
-    bottom: 0;
-    margin-top: 0.5rem;
-    height: 3.5rem;
     font-size: 1.3rem;
   }
 }

--- a/src/components/UIcontainer/StylesContainer.css
+++ b/src/components/UIcontainer/StylesContainer.css
@@ -1,8 +1,8 @@
 :root {
-    --background: #b4d7d0;
-    --nameEnterprise: #71431f;
-    --headers: #db1d29;
-    --sectionCircle: #b3dbd4;
+  --background: #b4d7d0;
+  --nameEnterprise: #71431f;
+  --headers: #db1d29;
+  --sectionCircle: #b3dbd4;
 }
 
 * {
@@ -13,29 +13,31 @@
 
 .ui-container {
   width: 100%;
+  min-height: 100vh;
+  background: var(--background);
 }
 
+html {
+  font-size: 87.5%;
+}
 
-@media (max-width: 1875px) {
+@media (min-width: 768px) {
   html {
     font-size: 93.75%;
   }
-} 
+}
 
-@media (max-width: 1080px) {
+@media (min-width: 1080px) {
   html {
-    font-size: 70%;
+    font-size: 100%;
   }
-} 
+}
 
-@media (max-width: 370px) {
-  html {
-    font-size: 69%;
-  }
-} 
-
-body, input, textarea, button  {
-  font-family: 'Poppins', sans-serif;
+body,
+input,
+textarea,
+button {
+  font-family: "Poppins", sans-serif;
   font-weight: 400;
 }
 


### PR DESCRIPTION
## Summary
- refactor global container styles to set base font size and layout
- restructure header layout and responsive rules
- update footer spacing and font scaling
- adjust form section widths for mobile first design
- refine modals and glitter components

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6843a79af1f0832e83ac6bc7da933d0f