### PR TITLE
Improve mobile layout

### DIFF
--- a/src/components/Footer/StylesFooter.css
+++ b/src/components/Footer/StylesFooter.css
@@ -25,3 +25,14 @@
     padding: 1.5rem;
   }
 }
+
+@media (max-width: 480px) {
+  .form-footer {
+    height: auto;
+    padding: 1rem;
+  }
+
+  .form-footer div {
+    font-size: 1rem;
+  }
+}

--- a/src/components/Form/FormStyle.css
+++ b/src/components/Form/FormStyle.css
@@ -322,6 +322,48 @@ option {
   }
 }
 
+@media (max-width: 480px) {
+  .form-container {
+    gap: 2rem;
+  }
+
+  .container-img {
+    width: 100%;
+    height: auto;
+  }
+
+  .imagem-avatar,
+  .imagem-balao {
+    width: 12rem;
+  }
+
+  .alert-section,
+  .warning-text,
+  .form-section-one,
+  .form-section-two,
+  .form-section-three,
+  .form-section-four,
+  .form-section-input-text,
+  .form-section-input-select,
+  .form-section-input-date,
+  .form-section-input-creditCard {
+    width: 95%;
+    padding: 1.5rem;
+  }
+
+  h2 {
+    font-size: 1.2rem;
+  }
+
+  label {
+    font-size: 1rem;
+  }
+
+  p {
+    font-size: 0.9rem;
+  }
+}
+
 @media (max-width: 370px) {
   input[type="date"] {
     width: 13rem;

--- a/src/components/Header/StylesHeader.css
+++ b/src/components/Header/StylesHeader.css
@@ -90,6 +90,23 @@
   }
 }
 
+@media (max-width: 480px) {
+  .header-container {
+    height: auto;
+    padding: 1rem 0;
+  }
+  .header-list {
+    justify-content: center;
+    gap: 1rem;
+  }
+  .logo-empresa {
+    height: 8rem;
+  }
+  .header-text h2 {
+    font-size: 1.1rem;
+  }
+}
+
 @media (max-width: 370px) {
   .logo-empresa {
     width: 100%;

--- a/src/components/UIcontainer/StylesContainer.css
+++ b/src/components/UIcontainer/StylesContainer.css
@@ -13,6 +13,9 @@
 
 .ui-container {
   width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 0 1rem;
 }
 
 
@@ -28,11 +31,20 @@
   }
 } 
 
+@media (max-width: 480px) {
+  html {
+    font-size: 62.5%;
+  }
+  .ui-container {
+    padding: 0 0.5rem;
+  }
+}
+
 @media (max-width: 370px) {
   html {
     font-size: 69%;
   }
-} 
+}
 
 body, input, textarea, button  {
   font-family: 'Poppins', sans-serif;


### PR DESCRIPTION
## Summary
- tighten layout container with max-width and padding
- adjust header and footer styles for small screens
- tweak form styles for better mobile readability

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68463792ccf0832e8365df3b46905d9c